### PR TITLE
silver 테이블 타입캐스팅과, 최소한의 NULL 처리 & airflow dag 분리

### DIFF
--- a/dags/gdelt_15min_pipeline_dag.py
+++ b/dags/gdelt_15min_pipeline_dag.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from airflow.models.dag import DAG
+from airflow.operators.bash import BashOperator
+import os
+import pendulum
+
+with DAG(
+    dag_id="gdelt_15min_pipeline",
+    start_date=pendulum.datetime(2025, 8, 26, tz="Asia/Seoul"),
+    schedule=None,  # 테스트용 임시 수동 트리거. 실제로는 15분 간격으로 실행되어야 함
+    catchup=False,
+    max_active_runs=1,  # 동시 실행 방지
+    doc_md="""
+    ### GDELT 전체 파이프라인 DAG
+    - 목적: Raw Producer → Kafka → MinIO Raw Bucket → Spark Processor → MinIO Silver Table
+    - 순서: Raw Producer → Kafka to MinIO → Silver Processor
+    """,
+) as dag:
+    # 공통 상수 정의
+    PROJECT_ROOT = "/opt/airflow"
+    SPARK_MASTER = "spark://spark-master:7077"
+
+    # GDELT Raw 데이터 Producer (Kafka로 전송)
+    gdelt_15min_to_kafka = BashOperator(
+        task_id="gdelt_15min_to_kafka",
+        bash_command=f"PYTHONPATH={PROJECT_ROOT} python {PROJECT_ROOT}/src/ingestion/gdelt/gdelt_15min_to_kafka.py",
+        env=dict(os.environ),
+    )
+
+    # Kafka to MinIO (Raw 데이터 저장)
+    task_kafka_to_minio = BashOperator(
+        task_id="kafka_raw_to_minio",
+        bash_command=(
+            f"spark-submit "
+            f"--master {SPARK_MASTER} "
+            f"--deploy-mode client "
+            f"{PROJECT_ROOT}/src/ingestion/gdelt/kafka_15min_raw_to_minio_consumer.py"
+        ),
+        env=dict(os.environ),
+    )
+
+    # Spark Processor (Kafka → MinIO Silver Table)
+    gdelt_15min_to_silver = BashOperator(
+        task_id="gdelt_15min_to_silver",
+        bash_command=(
+            f"spark-submit "
+            f"--master {SPARK_MASTER} "
+            f"--deploy-mode client "
+            f"{PROJECT_ROOT}/src/processing/batch/gdelt_15min_to_silver.py"
+        ),
+        env=dict(os.environ),
+    )
+
+    # Task 순서 정의
+    gdelt_15min_to_kafka >> task_kafka_to_minio >> gdelt_15min_to_silver

--- a/dags/gdelt_historycal_kafka_to_minio_dag.py
+++ b/dags/gdelt_historycal_kafka_to_minio_dag.py
@@ -25,7 +25,7 @@ with DAG(
     # 1. gdelt_producer.py 실행
     run_producer = BashOperator(
         task_id="run_gdelt_producer",
-        bash_command=f"python {project_root_in_container}/src/ingestion/gdelt/gdelt_producer.py",
+        bash_command=f"python {project_root_in_container}/src/ingestion/gdelt/gdelt_bigq_to_kafka.py",
     )
 
     # 2. kafka_to_minio_consumer.py 실행

--- a/src/ingestion/gdelt/gdelt_15min_to_kafka.py
+++ b/src/ingestion/gdelt/gdelt_15min_to_kafka.py
@@ -1,0 +1,146 @@
+"""
+GDELT Raw Data Producer - ZIP 파일에서 순수 RAW 데이터를 Kafka로 전송
+정제나 컬럼명 매핑 없이 순수 RAW 데이터만 전송
+"""
+
+import os
+import requests
+import zipfile
+import io
+import csv
+import json
+import time
+import logging
+from kafka import KafkaProducer
+from dotenv import load_dotenv
+from src.utils.kafka_producer import get_kafka_producer
+
+# 로깅 설정
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# .env 파일에서 설정값 로드
+load_dotenv()
+KAFKA_BOOTSTRAP_SERVERS = os.getenv("KAFKA_BOOTSTRAP_SERVERS", "kafka:29092")
+KAFKA_TOPIC = os.getenv("KAFKA_TOPIC_GDELT", "gdelt_raw_events")  # Raw 토픽
+
+
+def get_latest_gdelt_data_url():
+    """GDELT의 lastupdate.txt 파일을 읽고, 최근 15분 마이크로배치 데이터의 URL을 찾아 반환"""
+    try:
+        latest_gdelt_url = "http://data.gdeltproject.org/gdeltv2/lastupdate.txt"
+        response = requests.get(latest_gdelt_url)
+        response.raise_for_status()
+
+        # export.CSV.zip 찾기
+        for line in response.text.split("\n"):
+            if "export.CSV.zip" in line:
+                url = line.split(" ")[2]
+                logger.info(f"✅ Found latest GDELT data URL: {url}")
+                return url
+
+        logger.warning("⚠️ export.CSV.zip not found")
+        return None
+
+    except requests.exceptions.RequestException as e:
+        logger.error(f"❌ Failed to fetch latest GDELT URL: {e}")
+        return None
+
+
+def send_raw_data_to_kafka(url: str, producer: KafkaProducer):
+    """URL에서 GDELT 데이터를 다운로드하고, 순수 RAW 형태로 Kafka에 전송"""
+    try:
+        logger.info(f"📥 Downloading RAW data from: {url}")
+        response = requests.get(url, stream=True)
+        response.raise_for_status()
+
+        # 메모리 상에서 압축 해제
+        with zipfile.ZipFile(io.BytesIO(response.content)) as z:
+            csv_filename = z.namelist()[0]
+            logger.info(f"📄 Processing RAW file: {csv_filename}")
+
+            with z.open(csv_filename) as c:
+                # CSV 파일을 한 줄씩 읽어서 처리
+                # GDELT CSV는 탭으로 구분되어 있고, 헤더가 없음
+                reader = csv.reader(io.TextIOWrapper(c, "utf-8"), delimiter="\t")
+
+                record_count = 0
+                batch_records = []
+
+                for row_num, row in enumerate(reader, 1):
+                    try:
+                        # 순수 RAW 데이터 - 컬럼명 없이 리스트 형태로
+                        raw_record = {
+                            "raw_data": row,  # 전체 컬럼을 리스트로 (컬럼명 없음)
+                            "row_number": row_num,
+                            "source_file": csv_filename,
+                            "extracted_time": time.strftime("%Y-%m-%d %H:%M:%S"),
+                            "source_url": url,
+                            "total_columns": len(row),
+                        }
+
+                        batch_records.append(raw_record)
+                        record_count += 1
+
+                        # 배치 전송 (100개씩)
+                        if len(batch_records) >= 100:
+                            for record in batch_records:
+                                producer.send(KAFKA_TOPIC, record)
+                            batch_records = []
+
+                        # 진행상황 로그 (1000개마다)
+                        if record_count % 1000 == 0:
+                            logger.info(f"📤 Sent {record_count} RAW records...")
+
+                    except Exception as e:
+                        logger.warning(f"⚠️ Error processing row {row_num}: {e}")
+                        continue
+
+                # 남은 배치 전송
+                if batch_records:
+                    for record in batch_records:
+                        producer.send(KAFKA_TOPIC, record)
+
+        producer.flush()
+        logger.info(
+            f"🎉 Successfully sent {record_count} RAW records from {csv_filename}"
+        )
+        logger.info(f"📤 RAW data sent to Kafka topic: '{KAFKA_TOPIC}'")
+
+        return record_count
+
+    except Exception as e:
+        logger.error(f"❌ Error during RAW data processing: {e}", exc_info=True)
+        return 0
+
+
+def main():
+    """메인 실행 함수"""
+    logger.info("🚀 Starting GDELT Raw Data Producer...")
+
+    producer = None  # finally에서 producer 변수를 인식하도록 미리 선언
+
+    try:
+        # Kafka Producer 유틸을 사용해서 생성
+        producer = get_kafka_producer()
+
+        latest_url = get_latest_gdelt_data_url()
+        if latest_url:
+            send_raw_data_to_kafka(latest_url, producer)
+        else:
+            logger.error("❌ Could not get latest GDELT URL")
+
+    except Exception as e:
+        logger.error(f"❌ Failed to create Kafka producer: {e}")
+    finally:
+        if producer:
+            producer.close()
+            logger.info("✅ Raw Producer closed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/ingestion/gdelt/gdelt_bigq_to_kafka.py
+++ b/src/ingestion/gdelt/gdelt_bigq_to_kafka.py
@@ -1,0 +1,117 @@
+import os
+import json
+from google.cloud import bigquery
+from kafka import KafkaProducer
+from dotenv import load_dotenv
+
+
+def main():
+
+    # BigQuery에서 GDELT 데이터를 가져와 Kafka 토픽으로 전송하는 함수.
+
+    # 1. GCP 인증 설정
+    # .env 파일의 절대 경로를 직접 지정
+    project_root_in_container = "/opt/airflow"
+    dotenv_path = os.path.join(project_root_in_container, ".env")
+
+    # 지정된 경로의 .env 파일을 로드
+    load_dotenv(dotenv_path=dotenv_path)
+
+    try:
+        """
+        service_account_key_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+        if service_account_key_path and os.path.exists(service_account_key_path):
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = service_account_key_path
+            print(f"GCP 서비스 계정 키 로드.)")
+        else:
+            print(".env 파일에 키 없음")
+        """
+        # Airflow 컨테이너 내부의 프로젝트 루트는 '/opt/airflow'
+        project_root_in_container = "/opt/airflow"
+
+        # .env에서 상대 경로를 읽어옴
+        keyfile_relative_path = os.getenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+        if keyfile_relative_path:
+            # 컨테이너 내부의 절대 경로를 만들어줌
+            keyfile_absolute_path = os.path.join(
+                project_root_in_container, keyfile_relative_path
+            )
+
+            if os.path.exists(keyfile_absolute_path):
+                os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = keyfile_absolute_path
+                print("GCP 서비스 계정 키를 성공적으로 로드했습니다.")
+            else:
+                print(f"경고: 파일 경로를 찾을 수 없습니다: {keyfile_absolute_path}")
+                return  # 에러 발생 시 함수 종료
+        else:
+            print("경고: .env 파일에 GCP_KEYFILE_PATH가 없습니다.")
+            return  # 에러 발생 시 함수 종료
+    except Exception as e:
+        print(f"GCP 인증 설정 중 에러 발생: {e}")
+        return
+
+    # 2. BigQuery 클라이언트 생성
+    try:
+        bq_client = bigquery.Client()
+        print("BigQuery 클라이언트 생성 성공.")
+    except Exception as e:
+        print(f"BigQuery 클라이언트 생성 실패: {e}")
+        return
+
+    # 3. Kafka 프로듀서 생성
+    try:
+        producer = KafkaProducer(
+            bootstrap_servers=["kafka:29092"],
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        )
+        print("Kafka 프로듀서 생성 성공.")
+    except Exception as e:
+        print(f"Kafka 프로듀서 생성 실패: {e}")
+        return
+
+    # 4. BigQuery에서 데이터 가져오기
+    query = """
+        SELECT
+          SQLDATE,
+          Year,
+          Actor1CountryCode,
+          Actor2CountryCode,
+          EventCode,
+          QuadClass,
+          GoldsteinScale,
+          AvgTone,
+          NumMentions,
+          ActionGeo_CountryCode
+        FROM
+          `gdelt-bq.gdeltv2.events`
+        WHERE
+          SQLDATE >= 20250801
+        ORDER BY
+          SQLDATE DESC
+        LIMIT 5000
+    """
+    try:
+        print("BigQuery에 쿼리 실행 중...")
+        query_job_result = bq_client.query(query).result()
+        print(f"쿼리 완료. {query_job_result.total_rows}개의 행을 가져왔습니다.")
+    except Exception as e:
+        print(f"BigQuery 쿼리 실행 실패: {e}")
+        return
+
+    # 5. Kafka로 데이터 전송
+    topic_name = "gdelt_events"
+    try:
+        print(f"Kafka 토픽 '{topic_name}'으로 데이터 전송 시작...")
+        for row in query_job_result:
+            message = dict(row)
+            producer.send(topic_name, value=message)
+
+        producer.flush()
+        print("데이터 전송 완료.")
+    except Exception as e:
+        print(f"Kafka로 데이터 전송 실패: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/processing/batch/gdelt_15min_to_silver.py
+++ b/src/processing/batch/gdelt_15min_to_silver.py
@@ -1,0 +1,333 @@
+"""
+GDELT Silver Processor - Kafka Raw 데이터를 읽어서 정제 후 Silver Delta Table로 저장
+"""
+
+import sys
+from pathlib import Path
+
+# sys.path.append("/app") 대신, 이 파일의 위치를 기준으로 프로젝트 루트를 찾아서 경로에 추가한다.
+# 이렇게 하면 어떤 환경에서 실행해도 항상 프로젝트의 src 폴더를 찾을 수 있다.
+project_root = Path(__file__).resolve().parents[3]
+sys.path.append(str(project_root))
+
+from src.utils.spark_builder import get_spark_session
+from pyspark.sql import SparkSession, DataFrame, functions as F
+from pyspark.sql.types import *
+import time
+import logging
+
+# 로깅 설정
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+def get_gdelt_silver_schema():
+    """GDELT Silver Table 스키마 정의 (GDELT 2.0 코드북 기준)"""
+    return StructType(
+        [
+            # 기본 식별자
+            StructField("global_event_id", LongType(), False),
+            StructField("event_date", DateType(), True),
+            # 주체(Actor1) 정보
+            StructField("actor1_code", StringType(), True),
+            StructField("actor1_name", StringType(), True),
+            StructField("actor1_country_code", StringType(), True),
+            StructField("actor1_known_group_code", StringType(), True),
+            StructField("actor1_ethnic_code", StringType(), True),
+            StructField("actor1_religion1_code", StringType(), True),
+            StructField("actor1_religion2_code", StringType(), True),
+            StructField("actor1_type1_code", StringType(), True),
+            StructField("actor1_type2_code", StringType(), True),
+            StructField("actor1_type3_code", StringType(), True),
+            # 대상(Actor2) 정보
+            StructField("actor2_code", StringType(), True),
+            StructField("actor2_name", StringType(), True),
+            StructField("actor2_country_code", StringType(), True),
+            StructField("actor2_known_group_code", StringType(), True),
+            StructField("actor2_ethnic_code", StringType(), True),
+            StructField("actor2_religion1_code", StringType(), True),
+            StructField("actor2_religion2_code", StringType(), True),
+            StructField("actor2_type1_code", StringType(), True),
+            StructField("actor2_type2_code", StringType(), True),
+            StructField("actor2_type3_code", StringType(), True),
+            # 이벤트 정보
+            StructField("is_root_event", IntegerType(), True),
+            StructField("event_code", StringType(), True),
+            StructField("event_base_code", StringType(), True),
+            StructField("event_root_code", StringType(), True),
+            StructField("quad_class", IntegerType(), True),
+            StructField("goldstein_scale", DoubleType(), True),
+            StructField("num_mentions", IntegerType(), False),
+            StructField("num_sources", IntegerType(), False),
+            StructField("num_articles", IntegerType(), False),
+            StructField("avg_tone", DoubleType(), True),
+            # 주체1 지리정보
+            StructField("actor1_geo_type", IntegerType(), True), # 코드북 기준: Integer
+            StructField("actor1_geo_fullname", StringType(), True),
+            StructField("actor1_geo_country_code", StringType(), True),
+            StructField("actor1_geo_adm1_code", StringType(), True),
+            StructField("actor1_geo_adm2_code", StringType(), True),
+            StructField("actor1_geo_lat", DoubleType(), True),
+            StructField("actor1_geo_long", DoubleType(), True),
+            StructField("actor1_geo_feature_id", StringType(), True),
+            # 대상2 지리정보
+            StructField("actor2_geo_type", IntegerType(), True), # 코드북 기준: Integer
+            StructField("actor2_geo_fullname", StringType(), True),
+            StructField("actor2_geo_country_code", StringType(), True),
+            StructField("actor2_geo_adm1_code", StringType(), True),
+            StructField("actor2_geo_adm2_code", StringType(), True),
+            StructField("actor2_geo_lat", DoubleType(), True),
+            StructField("actor2_geo_long", DoubleType(), True),
+            StructField("actor2_geo_feature_id", StringType(), True),
+            # 사건 지리정보
+            StructField("action_geo_type", IntegerType(), True), # 코드북 기준: Integer
+            StructField("action_geo_fullname", StringType(), True),
+            StructField("action_geo_country_code", StringType(), True),
+            StructField("action_geo_adm1_code", StringType(), True),
+            StructField("action_geo_adm2_code", StringType(), True),
+            StructField("action_geo_lat", DoubleType(), True),
+            StructField("action_geo_long", DoubleType(), True),
+            StructField("action_geo_feature_id", StringType(), True),
+            # 추가 정보
+            StructField("date_added", TimestampType(), True),
+            StructField("source_url", StringType(), True),
+            # 메타데이터
+            StructField("processed_time", TimestampType(), False),
+            StructField("source_file", StringType(), True),
+        ]
+    )
+
+
+def transform_raw_to_silver(raw_df: DataFrame) -> DataFrame:
+    """Raw 데이터를 Silver 스키마에 맞게 정제하고 변환 (GDELT 2.0 코드북 기준)"""
+
+    # 1. 데이터 유효성 검사: raw_data 배열의 크기가 최소 58개 이상인 데이터만 처리
+    min_expected_columns = 58
+    
+    valid_df = raw_df.filter(F.size("raw_data") >= min_expected_columns)
+    invalid_df = raw_df.filter(F.size("raw_data") < min_expected_columns)
+
+    invalid_count = invalid_df.count()
+    if invalid_count > 0:
+        logger.warning(f"⚠️ Found {invalid_count} records with less than {min_expected_columns} columns. These records will be skipped.")
+
+    # 2. raw_data 배열에서 각 컬럼 추출 및 타입 캐스팅
+    silver_df = valid_df.select(
+        # 기본 식별자 (0-4)
+        F.col("raw_data")[0].cast(LongType()).alias("global_event_id"),
+        F.col("raw_data")[1].alias("event_date_str"),
+        # Actor1 (5-14)
+        F.col("raw_data")[5].alias("actor1_code"),
+        F.col("raw_data")[6].alias("actor1_name"),
+        F.col("raw_data")[7].alias("actor1_country_code"),
+        F.col("raw_data")[8].alias("actor1_known_group_code"),
+        F.col("raw_data")[9].alias("actor1_ethnic_code"),
+        F.col("raw_data")[10].alias("actor1_religion1_code"),
+        F.col("raw_data")[11].alias("actor1_religion2_code"),
+        F.col("raw_data")[12].alias("actor1_type1_code"),
+        F.col("raw_data")[13].alias("actor1_type2_code"),
+        F.col("raw_data")[14].alias("actor1_type3_code"),
+        # Actor2 (15-24)
+        F.col("raw_data")[15].alias("actor2_code"),
+        F.col("raw_data")[16].alias("actor2_name"),
+        F.col("raw_data")[17].alias("actor2_country_code"),
+        F.col("raw_data")[18].alias("actor2_known_group_code"),
+        F.col("raw_data")[19].alias("actor2_ethnic_code"),
+        F.col("raw_data")[20].alias("actor2_religion1_code"),
+        F.col("raw_data")[21].alias("actor2_religion2_code"),
+        F.col("raw_data")[22].alias("actor2_type1_code"),
+        F.col("raw_data")[23].alias("actor2_type2_code"),
+        F.col("raw_data")[24].alias("actor2_type3_code"),
+        # Event (25-34)
+        F.col("raw_data")[25].cast(IntegerType()).alias("is_root_event"),
+        F.col("raw_data")[26].alias("event_code"),
+        F.col("raw_data")[27].alias("event_base_code"),
+        F.col("raw_data")[28].alias("event_root_code"),
+        F.col("raw_data")[29].cast(IntegerType()).alias("quad_class"),
+        F.col("raw_data")[30].cast(DoubleType()).alias("goldstein_scale"),
+        F.col("raw_data")[31].cast(IntegerType()).alias("num_mentions"),
+        F.col("raw_data")[32].cast(IntegerType()).alias("num_sources"),
+        F.col("raw_data")[33].cast(IntegerType()).alias("num_articles"),
+        F.col("raw_data")[34].cast(DoubleType()).alias("avg_tone"),
+        # Actor1 Geo (35-42)
+        F.col("raw_data")[35].cast(IntegerType()).alias("actor1_geo_type"),
+        F.col("raw_data")[36].alias("actor1_geo_fullname"),
+        F.col("raw_data")[37].alias("actor1_geo_country_code"),
+        F.col("raw_data")[38].alias("actor1_geo_adm1_code"),
+        F.col("raw_data")[39].alias("actor1_geo_adm2_code"),
+        F.col("raw_data")[40].cast(DoubleType()).alias("actor1_geo_lat"),
+        F.col("raw_data")[41].cast(DoubleType()).alias("actor1_geo_long"),
+        F.col("raw_data")[42].alias("actor1_geo_feature_id"),
+        # Actor2 Geo (43-50)
+        F.col("raw_data")[43].cast(IntegerType()).alias("actor2_geo_type"),
+        F.col("raw_data")[44].alias("actor2_geo_fullname"),
+        F.col("raw_data")[45].alias("actor2_geo_country_code"),
+        F.col("raw_data")[46].alias("actor2_geo_adm1_code"),
+        F.col("raw_data")[47].alias("actor2_geo_adm2_code"),
+        F.col("raw_data")[48].cast(DoubleType()).alias("actor2_geo_lat"),
+        F.col("raw_data")[49].cast(DoubleType()).alias("actor2_geo_long"),
+        F.col("raw_data")[50].alias("actor2_geo_feature_id"),
+        # Action Geo (51-58)
+        F.col("raw_data")[51].cast(IntegerType()).alias("action_geo_type"),
+        F.col("raw_data")[52].alias("action_geo_fullname"),
+        F.col("raw_data")[53].alias("action_geo_country_code"),
+        F.col("raw_data")[54].alias("action_geo_adm1_code"),
+        F.col("raw_data")[55].alias("action_geo_adm2_code"),
+        F.col("raw_data")[56].cast(DoubleType()).alias("action_geo_lat"),
+        F.col("raw_data")[57].cast(DoubleType()).alias("action_geo_long"),
+        F.col("raw_data")[58].alias("action_geo_feature_id"),
+        # Data Mgmt (59-60)
+        F.col("raw_data")[59].alias("date_added_str"),
+        F.col("raw_data")[60].alias("source_url"),
+        # 메타데이터
+        F.current_timestamp().alias("processed_time"),
+        F.col("source_file"),
+    ).filter(F.col("global_event_id").isNotNull())
+
+    # 3. 데이터 정제 및 변환
+    silver_df = silver_df.withColumn(
+        "event_date", F.to_date(F.col("event_date_str"), "yyyyMMdd")
+    ).withColumn(
+        "date_added", F.to_timestamp(F.col("date_added_str"), "yyyyMMddHHmmss")
+    ).drop("event_date_str", "date_added_str")
+
+    # 4. 빈 문자열을 NULL로 변환
+    string_columns = [f.name for f in silver_df.schema.fields if isinstance(f.dataType, StringType)]
+    for col_name in string_columns:
+        silver_df = silver_df.withColumn(
+            col_name,
+            F.when(F.trim(F.col(col_name)) == "", None).otherwise(F.col(col_name)),
+        )
+
+    # 5. NULL 값을 기본값(0)으로 채우기
+    silver_df = silver_df.fillna({
+        "num_mentions": 0,
+        "num_sources": 0,
+        "num_articles": 0
+    })
+    
+    # 6. 최종 스키마에 맞게 컬럼 순서 정리 및 선택
+    final_columns = [f.name for f in get_gdelt_silver_schema().fields]
+    silver_df = silver_df.select(final_columns)
+
+    return silver_df
+
+
+def setup_silver_table(
+    spark: SparkSession, table_name: str, silver_path: str, schema: StructType
+):
+    # 경쟁 상태를 방지하기 위해 Silver 테이블 구조를 미리 생성
+    db_name = table_name.split(".")[0]
+    logger.info(
+        f"🚩 Preemptively creating database '{db_name}' and table '{table_name}'..."
+    )
+    spark.sql(f"CREATE DATABASE IF NOT EXISTS {db_name}")
+
+    empty_df = spark.createDataFrame([], schema)
+    (
+        empty_df.write.format("delta")
+        .mode("ignore")
+        .option("overwriteSchema", "true")
+        .saveAsTable(table_name, path=silver_path)
+    )
+    logger.info(f"🚩 Table '{table_name}' structure is ready at {silver_path}.")
+
+
+def read_from_kafka(spark: SparkSession) -> DataFrame:
+    # Kafka에서 Raw 데이터를 읽어 DataFrame으로 반환
+    logger.info("📥 Reading RAW data from Kafka...")
+    raw_df = (
+        spark.read.format("kafka")
+        .option("kafka.bootstrap.servers", "kafka:29092")
+        .option("subscribe", "gdelt_raw_events")
+        .option("startingOffsets", "earliest")
+        .option("endingOffsets", "latest")
+        .load()
+    )
+    # Kafka 메시지 파싱
+    parsed_df = raw_df.select(
+        F.from_json(
+            F.col("value").cast("string"),
+            StructType(
+                [
+                    StructField("raw_data", ArrayType(StringType()), True),
+                    StructField("row_number", IntegerType(), True),
+                    StructField("source_file", StringType(), True),
+                    StructField("extracted_time", StringType(), True),
+                    StructField("source_url", StringType(), True),
+                    StructField("total_columns", IntegerType(), True),
+                ]
+            ),
+        ).alias("data")
+    ).select("data.*")
+    return parsed_df
+
+
+def write_to_silver(df: DataFrame, silver_path: str):
+    # 변환된 DataFrame을 Silver Layer에 덮어쓴다 (단일 파일로)
+    logger.info("💾 Saving data to Silver Delta Table...")
+    record_count = df.count()
+    if record_count == 0:
+        logger.warning("⚠️ No records to save!")
+        return
+
+    (
+        df.coalesce(1)
+        .write.format("delta")
+        .mode("overwrite")
+        .option("overwriteSchema", "true")
+        .save(silver_path)
+    )
+    logger.info(f"🎉 Successfully saved {record_count} records to {silver_path}")
+
+
+def main():
+    # 메인 실행 함수
+    logger.info("🚀 Starting GDELT Silver Processor...")
+
+    # Kafka 지원을 위해 get_spark_session 사용
+    spark = get_spark_session("GDELT Silver Processor", "spark://spark-master:7077")
+
+    try:
+        # 1. 빈 테이블을 선점 해야함.
+        silver_schema = get_gdelt_silver_schema()
+        setup_silver_table(
+            spark,
+            "default.gdelt_silver_events",
+            "s3a://warehouse/silver/gdelt_events",
+            silver_schema,
+        )
+
+        # 2. 데이터 처리 로직
+        parsed_df = read_from_kafka(spark)
+        if parsed_df.rdd.isEmpty():
+            logger.warning("⚠️ No RAW data found in Kafka. Exiting gracefully.")
+            return
+
+        # 3. 데이터 변환
+        silver_df = transform_raw_to_silver(parsed_df)
+
+        # 4. 데이터 저장
+        write_to_silver(silver_df, "s3a://warehouse/silver/gdelt_events")
+
+        # 5. 샘플 데이터 확인
+        logger.info("🔍 Sample final Silver data:")
+        silver_df.select(
+            "global_event_id",
+            "event_date",
+            "actor1_country_code",
+            "event_root_code",
+            "avg_tone",
+            "num_mentions"
+        ).show(5)
+
+    except Exception as e:
+        logger.error(f"❌ Error in Silver processing: {e}", exc_info=True)
+
+    finally:
+        spark.stop()
+        logger.info("✅ Spark session closed")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
airflow dag과 파이프라인에 사용된 코드들을 새로 분리했습니다.

GlobalEventID, EventCode, event_date < 해당 핵심 칼럼에 대해서는 NULL값을 제거했습니다.
위 데이터가 없으면 정보 식별이 불가능하다고 판단되었습니다.

NumMentions, NumSources, NumArticles < 집계가 필요한 필드는 null 을 0으로 인코딩했습니다.
언급 횟수 등과 같은 값은 null 일 때 0 으로 해석해도 문제가 없다고 판단했습니다.

액터 1 , 액터 2 , GoldsteinScale등은 NULL 값을 UNKNOWN 으로 처리하는 것은 실버 테이블이 아닌 골드 테이블에서 해야 할 것이라고 판단되어서 일단 보류했습니다. 
왜냐하면 dbt에서 sql문으로 데이처를 처리할 때, sql문에서 지원하는 기본 NULL값을 표준 처리를 할 수 없을 것으로 판단되었고, 또한 영향을 받는 국가가 없는 것인지, 아니면 모르는 것인지 애매하기 때문에 데이터 무결성을 해치고 보는 사람의 혼란을 야기할 수 있을거라 판단했기 때문입니다.